### PR TITLE
Dynamic containers + Named &&|| Default (ex/im)ports

### DIFF
--- a/app/components/Layout/Container.js
+++ b/app/components/Layout/Container.js
@@ -9,9 +9,10 @@ function Container({children, style, ...rest}) {
   );
 }
 
-const styles = ({m, mH, mB, mT}) => StyleSheet.create({
+const styles = ({m, mH, mB, mT, bgColor}) => StyleSheet.create({
   container: {
     flex: 1,
+    backgroundColor: bgColor,
     margin: m,
     marginHorizontal: mH,
     marginBottom: mB,

--- a/app/components/Layout/Screen.js
+++ b/app/components/Layout/Screen.js
@@ -1,13 +1,9 @@
 import React from 'react';
 import { StyleSheet, SafeAreaView, View } from 'react-native';
-import { sizes, colors } from '../../config/index';
+import appConstants from '../../config';
 
 function Screen({children}) {
-  const appConstants = {
-    sizes,
-    colors,
-  }
-  console.log(appConstants)
+  // console.log(appConstants)
 
   return (
     <SafeAreaView style={styles(appConstants).screen}>
@@ -22,11 +18,10 @@ const styles = ({ sizes, colors }) => StyleSheet.create({
   screen: {
     flex: 1,
     paddingTop: sizes.statusBar,
-    backgroundColor: colors.secondary,
+    backgroundColor: colors.highlight,
   },
   content: {
     backgroundColor: colors.primaryDarker,
-
     flex: 1,
 
     // alignSelf: 'center',

--- a/app/config/index.js
+++ b/app/config/index.js
@@ -1,2 +1,5 @@
-export { default as colors } from './colors'
-export { default as sizes } from './sizes'
+import colors from './colors'
+import sizes from './sizes'
+
+export { colors, sizes }
+export default { colors, sizes }

--- a/app/screens/Sandbox.js
+++ b/app/screens/Sandbox.js
@@ -1,23 +1,46 @@
 import React, {Fragment} from 'react';
-import { View, StyleSheet, Text } from 'react-native';
+import { StyleSheet, Text } from 'react-native';
 import Container from '../components/Layout/Container';
+import appConstants, { sizes, colors } from '../config';
 
 function Sandbox() {
+  console.log('DEFAULT', appConstants)
+  console.log('NAMED', sizes)
+  // const {sizes} = appConstants; // when not imported as named import
+
   return (
     <Fragment>
       <Container
-        style={{backgroundColor: 'purple', flexDirection: 'row', justifyContent: 'space-between'}}
-        mB={16}
+        style={{flexDirection: 'row', justifyContent: 'space-between'}}
+        mB={sizes.spacerVertical}
+        bgColor={'purple'}
+        // THIS Container JUST USES flex: 1 TO FILL THE AVAILABLE SCREEN SPACE
       >
         <Text>Hello</Text>
         <Text>Hello</Text>
       </Container>
+
+
       <Container
-        style={{backgroundColor: 'orange', flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}
-        mH={8}
+        style={{flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-end'}}
+        mH={sizes.spacerHorizontal}
+        bgColor={'orange'}
+        // THIS Container USES sizes.spacerHorizontal TO DEFINE IT'S MARGIN *RELATIVE* TO ITS PARENT CONTAINER 
       >
         <Text>Hello</Text>
         <Text style={{backgroundColor: 'green', borderColor: 'white', borderWidth: 1}}>Hello</Text>
+      </Container>
+
+
+      <Container
+        style={{flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-end', width: sizes.fullWidth, alignSelf: 'center', flex: 0}}
+        mT={sizes.spacerVertical}
+        bgColor={'green'}
+        // THIS Container USES width: sizes.fullWidth + alignSelf: 'center' TO FILL THE WIDTH OF ITS PARENT CONTAINER (SIMULATING IT'S PARENT[?] AS POSITION *ABSOLUTE*.)
+        //
+      >
+        <Text>Hello</Text>
+        <Text style={{backgroundColor: 'orange', borderColor: 'white', borderWidth: 1}}>Hello</Text>
       </Container>
     </Fragment>
   );


### PR DESCRIPTION
Named & Default exported config data (sizes & colors)
Updated import in Screen, tested both imports in Sandbox
Last two containers in Sandbox behave similarly with different properties (relative vs absolute) used to fill screen up to set margins.
Containers can now take background color as a prop (Mostly for testing purposes but could actually be a useful prop for this component).